### PR TITLE
Drop redundant type annotations; fix trait and constructor doc text

### DIFF
--- a/src/definitions.md
+++ b/src/definitions.md
@@ -117,7 +117,7 @@ trait Printable is
 si
 ```
 
-Traits are similar to interfaces in other languages. The methods and properties of the trait must be implemented by any class that inherits from the trait:
+Traits are similar to interfaces in other languages. Trait methods and properties without a default implementation must be implemented by any class that inherits from the trait:
 ```ghul
 class BOOK: Printable is
     title: string;
@@ -134,7 +134,7 @@ class BOOK: Printable is
 si
 ```
 
-Traits can only be defined at global scope. Trait methods and properties must be made abstract by giving them empty bodies (see issue [#285](https://github.com/degory/ghul/issues/285)). Trait names should be in `PascalCase`;
+Traits can only be defined at global scope. Trait methods and properties can be abstract or have a default implementation. Trait names should be in `PascalCase`.
 
 ### unions
 

--- a/src/generics.md
+++ b/src/generics.md
@@ -33,8 +33,8 @@ si
 ```
 
 ```ghul
-let holds_int = HOLD_SOMETHING[int](1234);
-let holds_string = HOLD_SOMETHING[string]("hello");
+let holds_int = HOLD_SOMETHING(1234);
+let holds_string = HOLD_SOMETHING("hello");
 ```
 
 ```ghul
@@ -43,7 +43,7 @@ union Option[T] is
     NONE;
 si
 
-let some_int = Option.SOME[int](1234);
+let some_int = Option.SOME(1234);
 ```
 
 Generic argument types are largely opaque: the operations permitted on values of generic argument types are limited to:
@@ -53,7 +53,7 @@ Generic argument types are largely opaque: the operations permitted on values of
 - method calls supported by `object`
 
 
-Generic argument types must be explicitly specified when constructing objects but can be inferred from context for generic function and method calls
+Generic argument types can be inferred from context for generic constructor invocations as well as generic function and method calls
 
 ```ghul
 print_something(1234); // T inferred as int

--- a/src/index.md
+++ b/src/index.md
@@ -43,9 +43,9 @@ use IO.Std.write_line;
 
 entry() is
     // lazily generates an infinite sequence of fibonacci numbers:
-    let fibonacci_sequence = GENERATE(
+    let fibonacci_sequence = GENERATOR(
         (0, 1),
-        state: (int, int) =>
+        state =>
             let 
                 (prev, current) = state,
                 next = prev + current
@@ -54,9 +54,9 @@ entry() is
     );
 
     // lazily generates an infinite sequence of factorials:
-    let factorial_sequence = GENERATE(
+    let factorial_sequence = GENERATOR(
         (1, 1),
-        state: (int, int) =>
+        state =>
             let
                 (p, prev) = state,
                 n = p + 1,


### PR DESCRIPTION
- Fix GENERATE → GENERATOR typo in index.md fibonacci example
- Drop now-inferred lambda \`state\` arg type annotations in index.md
- Drop now-inferred generic type args from constructor calls in generics.md
- Correct generics.md claim that constructor type args must be explicit
- Correct definitions.md claim that trait methods/properties must be abstract