### PR TITLE
Update deploy workflow; fix broken example snippets

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,12 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
-          node-version: '16' # Set the Node.js version
+          node-version: '20'
 
       - name: Install dependencies
         run: npm install
@@ -24,7 +24,7 @@ jobs:
         run: npm run build
 
       - name: Upload dist folder
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: dist
           path: ./src/.vuepress/dist/

--- a/src/definitions.md
+++ b/src/definitions.md
@@ -197,7 +197,7 @@ si
 class Sized is
     _size: int;
 
-    size: int => size,
+    size: int => _size,
         = new_size is
             assert new_size > 0;
 

--- a/src/expressions.md
+++ b/src/expressions.md
@@ -43,9 +43,9 @@ let unicode = "ghūl programming language"
 Array literals are constructed from a comma separated list of element values enclosed in `[` and `]`. The array element type is inferred as the most specific type compatible with all elements (which may be `object` if no more specific ancestor type exists). The resulting array type is `E[]` where `E` is the inferred element type. 
 
 ```ghul
-let animals = ["frog", "bat", "elephant"]; // List[string]
-let things = ["frog", 1234, 12.5] // List[object]
-let lists = [[1, 2], [3, 4], [5, 6], [7, 7]] // List[List[int]]
+let animals = ["frog", "bat", "elephant"]; // string[]
+let things = ["frog", 1234, 12.5]; // object[]
+let lists = [[1, 2], [3, 4], [5, 6], [7, 7]]; // int[][]
 ```
 
 ### tuple

--- a/src/functional-programming.md
+++ b/src/functional-programming.md
@@ -11,11 +11,11 @@ pretty much anything else you can do with any other ghūl value
 
 ```ghul
 let f = (i: int) => i * 2;
-f();
+f(123);
 let g = f;
-g();
+g(456);
 
-let ff(f: int -> int, i: int) => f(f(i));
+let ff = (f: int -> int, i: int) => f(f(i));
 ```
 
 ## filter, map, reduce
@@ -102,9 +102,9 @@ let list = [1, 2, 3, 4, 5];
 let element = list[3]; // elements can be read
 
 // the list is an instance of an immutable type:
-assert list.get_type() == typeof Collections.List[int];
+assert list.get_type() == typeof int[];
 
-element[3] = 6; // elements cannot be assigned to - compile time error
+list[3] = 6; // elements cannot be assigned to - compile time error
 ```
 
 ### tuples are immutable
@@ -119,7 +119,7 @@ let tuple = (1, 2, 3, 4, 5);
 let element = tuple.`3; // elements can be read
 
 // the tuple is an instance of an immutable type:
-assert tuple.get_type == typeof (int, int, int, int, int)
+assert tuple.get_type() == typeof (int, int, int, int, int);
 
 tuple.`3 = 6; // elements cannot be assigned to - compile time error
 ```


### PR DESCRIPTION
Bugs fixed:
- First-class functions example called f/g with no args and used invalid \`let ff(...)\` syntax
- Array-immutability assert had wrong type claim and assignment used wrong variable
- Tuple-immutability assert missed \`()\` on get_type and the terminating \`;\`
- Array literal type comments said \`List[T]\`; actual literal type is \`T[]\`
- \`Sized\` property getter recursed (\`size: int => size\`); should be \`_size\`

Technical:
- Bump deploy workflow actions to v4 and Node 20