### PR TITLE
Document trait defaults, type narrowing, discard `_`, union `=~`; fix VuePress build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+      NODE_OPTIONS: --openssl-legacy-provider
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4
@@ -15,7 +18,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install dependencies
         run: npm install

--- a/src/control-flow.md
+++ b/src/control-flow.md
@@ -101,6 +101,48 @@ else
 fi
 ```
 
+### type narrowing
+
+When an `if` predicate proves a stronger fact about a variable's type, the then-branch sees that variable at the narrower type. The most common cases are union variant tags and `isa` class tests:
+
+```ghul
+union Maybe[T] is
+    YES(value: T);
+    NO;
+si
+
+let m: Maybe[int] = Maybe.YES(42);
+
+if m.is_yes then
+    // m is narrowed to Maybe.YES inside the branch, so m.value is in scope
+    write_line("got value {m.value}");
+fi
+
+let a: Animal = Cat("whiskers");
+if isa Cat(a) then
+    // a is narrowed to Cat inside the branch
+    write_line(a.purr());
+fi
+```
+
+For a two-variant union, the `else` branch is also narrowed to the complementary variant:
+
+```ghul
+union Result[T, E] is
+    OK(value: T);
+    ERR(error: E);
+si
+
+let r: Result[int, string] = some_call();
+
+if r.is_ok then
+    write_line("ok: {r.value}");
+else
+    // r is narrowed to Result.ERR here
+    write_line("err: {r.error}");
+fi
+```
+
 ### scope
 Each branch of an if statement constitutes a separate scope
 

--- a/src/definitions.md
+++ b/src/definitions.md
@@ -26,6 +26,17 @@ Multiple variables can be defined in the same `let` statement, including a mix o
 let initialize_now = 123, initialize_later: int, why_are_we_doing_this = "I don't know";
 ```
 
+The name `_` is a discard placeholder. It binds wherever a name would normally bind, but the bound value is discarded. `_` is repeatable in a single scope, and is accepted in `let` bindings, tuple destructuring, lambda parameters, and `for` loop variables:
+
+```ghul
+let _ = side_effect();
+let (_, _, third) = (1, 2, 3);
+let only_first = (x: int, _: int) => x;
+for _ in 1..10 do
+    counter = counter + 1;
+od
+```
+
 Variables may only be defined within functions, methods or property bodies. Variables names should be in `snake_case`
 
 ## functions
@@ -134,6 +145,31 @@ class BOOK: Printable is
 si
 ```
 
+A trait method or property can provide a default body. Implementing classes inherit the default and only need to override it to change the behaviour:
+
+```ghul
+trait Logged is
+    log() is
+        write_line("(no log message provided)");
+    si
+si
+
+class SILENT: Logged is
+    init() is si
+si
+
+class NOISY: Logged is
+    init() is si
+
+    log() is
+        super.log();
+        write_line("plus my own message");
+    si
+si
+```
+
+A class override can call the trait's default with `super.method()`.
+
 Traits can only be defined at global scope. Trait methods and properties can be abstract or have a default implementation. Trait names should be in `PascalCase`.
 
 ### unions
@@ -166,6 +202,17 @@ if tree.is_node then
 elif tree.is_leaf then
     write_line("have a leaf with value {tree.leaf}"); // note we don't need tree.leaf.value here
 fi
+```
+
+Unions support structural equality through the `=~` operator. Two union references compare equal when they hold the same variant with member-wise equal fields:
+
+```ghul
+let leaf1 = Tree.LEAF(123);
+let leaf2 = Tree.LEAF(123);
+let leaf3 = Tree.LEAF(456);
+
+assert leaf1 =~ leaf2;
+assert !(leaf1 =~ leaf3);
 ```
 
 Unions can only be defined at global scope. Union names should be in `PascalCase` and variant names should be in `MACRO_CASE`


### PR DESCRIPTION
Enhancements:
- definitions.md: trait default methods and properties, with super-call from a class override
- definitions.md: \`_\` as a discard placeholder, valid in let bindings, destructuring, lambda parameters and for loop variables
- definitions.md: structural equality on unions via \`=~\`
- control-flow.md: type narrowing in \`if\` branches — variant-tag, \`isa\`, and two-variant union else

Technical:
- Set NODE_OPTIONS=--openssl-legacy-provider so the VuePress 1.x build's MD4 use works on Node 17+ runtimes
- Set FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 to silence the Node 20 action-runtime deprecation warning
- Bump setup-node version 20 → 22