### PR TITLE
Document recent inference improvements; switch homepage example to stream()

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -40,29 +40,20 @@ entry() =>
 
 ```ghul
 use IO.Std.write_line;
+use Ghul.Pipes.stream;
 
 entry() is
     // lazily generates an infinite sequence of fibonacci numbers:
-    let fibonacci_sequence = GENERATOR(
-        (0, 1),
-        state =>
-            let 
-                (prev, current) = state,
-                next = prev + current
-            in
-                ((current, next), next)
+    let fibonacci_sequence = stream(
+        (prev = 1, current = 1),
+        s => s.current || (prev = s.current, current = s.prev + s.current)
     );
 
     // lazily generates an infinite sequence of factorials:
-    let factorial_sequence = GENERATOR(
-        (1, 1),
-        state =>
-            let
-                (p, prev) = state,
-                n = p + 1,
-                next = prev * n
-            in
-                ((n, next), next)            
+    let factorial_sequence = stream(
+        (n = 1, prev = 1),
+        s => let next_n = s.n + 1, next = s.prev * next_n in
+            next || (n = next_n, prev = next)
     );
 
     write_line("first 10 fibonacci numbers: {fibonacci_sequence | .take(10)}");

--- a/src/type-inference.md
+++ b/src/type-inference.md
@@ -111,3 +111,63 @@ When anonymous function literals are passed as arguments to a function or method
 [1, 2, 2, 4, 5] | .filter(i => i > 3);
 ```
 In this example, `self` is already known to be `Pipe[int]`, so `Pipe[int].filter(predicate: int -> bool) -> Pipe[int]` is the only overload that could match. Hence the `predicate` argument must be `int -> bool` and the type of `i` must be `int`
+
+## inference from later use sites
+
+The sections above describe types being inferred from the right hand side of a declaration or from the value passed at a call site. When a binding has no immediate clue, the compiler also looks at how it is later used in the same method body and feeds that information back
+
+```ghul
+let m = Box();   // m is Box[?] here — the type argument is not yet known
+m.set(42);       // the set call carries an int, so m is Box[int]
+let x = m.get(); // x reads as int
+```
+
+The same applies to let-bound anonymous functions whose argument types are not annotated. A later call supplies a concrete type which flows back to the function literal
+
+```ghul
+let f = x => x + 1;
+write_line("{f(42)}");        // f's argument is inferred as int
+```
+
+## recursive anonymous functions
+
+In a recursive anonymous function, the argument type can be inferred from how the function is called, including from its own recursive calls
+
+```ghul
+let factorial = n rec => if n == 0 then 1 else n * rec(n - 1) fi;
+write_line("{factorial(5)}");
+```
+
+## operations on a not yet inferred value
+
+When the argument of an anonymous function has no annotation and the body uses it — accessing a member, calling a method, indexing, iterating, or destructuring — the compiler records what the argument must support. When a call later supplies a concrete type, candidate types are filtered against those operations
+
+```ghul
+let length_of = x => x.length;
+write_line("{length_of("hello")}"); // x resolves to string
+```
+
+## generic argument inference from sibling actuals
+
+When a generic function or method is called with two arguments that share only a common ancestor, the generic argument is inferred from their nearest shared type rather than failing the overload match
+
+```ghul
+class Animal is
+    init() is si
+    speak() -> string => "animal";
+si
+
+class Cat: Animal is
+    init() is si
+si
+
+class Dog: Animal is
+    init() is si
+si
+
+merge[T](a: T, b: T) -> T => a;
+
+...
+
+let a = merge(Cat(), Dog()); // T is inferred as Animal
+```


### PR DESCRIPTION
Enhancements:
- New type-inference.md sections: inference from later use sites,
  recursive anonymous functions, operations on a not yet inferred
  value, and generic argument inference from sibling actuals. Each
  has a short example matching the patterns the compiler now
  resolves without annotations.

Bugs fixed:
- The homepage functional example was still constructing
  fibonacci_sequence and factorial_sequence with the old hand-rolled
  GENERATOR class workaround removed by the move to runtime
  stream()/STREAM[T, S]. Replaced with the named-tuple state form
  used in functional-programming.md.