### PR TITLE
Document the `default` value expression

### DIFF
--- a/src/expressions.md
+++ b/src/expressions.md
@@ -232,6 +232,21 @@ Type cast expressions allow you to explicitly convert a value from one type to a
 let integer_value = cast int(3.14);
 ```
 
+## default value
+
+A `default` expression evaluates to the default value of a type: `null` for reference types, the zero value for numeric and other value types.
+
+`default[T]` pins the type explicitly. A bare `default` takes its type from the surrounding context — a typed `let`, an assignment, or a return:
+
+```ghul
+let a = default[int];   // 0
+let b: string = default;   // null
+
+zero[T]() -> T => default;
+```
+
+`let a = default` initialises a local to its type's default value, where the type is inferred from how the local is later used.
+
 These are the main types of expressions in ghūl. They can be combined and nested to form more complex expressions and statements:
 
 

--- a/src/object-oriented-programming.md
+++ b/src/object-oriented-programming.md
@@ -73,8 +73,7 @@ class CALCULATOR[T] is
         fi;
 
     clear_memory() is
-        let def: T; // uninitialized variable has default value
-        memory = def;
+        memory = default;
     si
 si
 


### PR DESCRIPTION
- add a `default value` section to the expressions reference
- use `default` in the object-oriented calculator example, replacing the uninitialized-local placeholder