### PR TITLE
Type inference page improvements

### DIFF
--- a/src/type-inference.md
+++ b/src/type-inference.md
@@ -1,6 +1,121 @@
 # type inference
 
-## let statements and expressions
+ghūl infers types pervasively. Inside a function body most local variables, loop variables, destructured bindings and lambda parameters can be left unannotated — the compiler works their types out from how they are initialized and from how they are later used.
+
+Two boundaries are worth understanding up front, because together they explain both what inference will do for you and what it will not:
+
+- Inference is **function-local**. The compiler works within one function body at a time. A function's signature — its parameter types and, where it returns a value, its return type — is always written out explicitly.
+- Inference applies to **local symbols** only. Local variables, loop variables, destructured bindings and lambda parameters have inferred types. Fields and properties carry declared types.
+
+The same two boundaries govern type narrowing: a local can be narrowed by a test that proves a stronger fact about it, but a field or property cannot.
+
+## inference is function-local
+
+A function's signature is written out explicitly. Inference then has free rein inside the body
+
+```ghul
+// the signature is explicit: the parameter type and the return type are written out
+totals(values: Collections.Iterable[int]) -> (sum: int, count: int) is
+    let sum = 0;        // inferred: int
+    let count = 0;      // inferred: int
+
+    for v in values do  // inferred: v is int
+        sum = sum + v;
+        count = count + 1;
+    od
+
+    (sum, count);
+si
+```
+
+Inference does not flow the other way. It never reads a type back out of a function body into that function's signature, and it never crosses from one function into another. Each body is checked on its own, against the fixed signatures of everything it calls.
+
+This is what makes signatures the stable contract between functions — and it is also why a named function's return type is written out, while an anonymous function's return type is inferred: a lambda has no separate signature to honour, so there is nothing for an explicit return type to agree with.
+
+## inference applies to local symbols
+
+A field or property is part of a type's surface — other code relies on its type — so its type is declared. A local variable exists only for the duration of one call, so the compiler is free to infer it
+
+```ghul
+class COUNTER is
+    count: int;          // a property — its type is declared
+
+    init() is
+        count = 0;
+    si
+
+    tick() is
+        let step = 1;    // a local — its type is inferred from the initializer
+        count = count + step;
+    si
+si
+```
+
+## narrowing respects the same boundary
+
+When a test proves a stronger fact about a value's type, ghūl narrows that value to the narrower type for the code the fact covers. Narrowing applies to local symbols — including a function's own parameters, which are locals of that function
+
+```ghul
+greet(a: Animal) is
+    if isa Cat(a) then
+        // a is a local of greet, narrowed to Cat in this branch
+        write_line(a.purr());
+    fi
+si
+```
+
+A field or property is **not** narrowed, even by a test written directly against it
+
+```ghul
+class CAGE is
+    occupant: Animal;
+
+    init(occupant: Animal) is
+        self.occupant = occupant;
+    si
+si
+
+...
+
+describe(cage: CAGE) is
+    if isa Cat(cage.occupant) then
+        // cage.occupant is a property access, not a local — it is not narrowed,
+        // so cage.occupant.purr() would not compile here
+        write_line("the cage holds a cat");
+    fi
+si
+```
+
+The compiler cannot carry the proven fact from the test to a later use, because a property access is re-evaluated every time it is written — there is no single, stable location to track. A field could be reassigned between the two points. A local that is not reassigned in between gives the compiler something it can rely on.
+
+To narrow a property, copy it into a local and test the local
+
+```ghul
+describe(cage: CAGE) is
+    let occupant = cage.occupant;  // copy the property into a local
+
+    if isa Cat(occupant) then
+        // occupant is a local, narrowed to Cat in this branch
+        write_line(occupant.purr());
+    fi
+si
+```
+
+`if let` does the same in one step: it binds a fresh local from the property expression, and that local narrows
+
+```ghul
+describe(cage: CAGE) is
+    if let cat: Cat = cage.occupant then
+        write_line(cat.purr());
+    fi
+si
+```
+
+Narrowing covers union variant tags, `isa` class tests, null tests (`x?`) and `if let` bindings, and it is flow-sensitive — an early-return guard narrows the code that follows it. See [type narrowing and `if let`](/control-flow.html#type-narrowing) in the control flow chapter for the full picture.
+
+## what gets inferred
+
+### let statements and expressions
 
 When no explicit type is given for a variable in a let statement or expression, the variable type is inferred from the initializer, provided one is present
 
@@ -10,7 +125,7 @@ let an_int = 12345;
 let an_int_array = [1, 2, 3, 4, 5];
 ```
 
-## destructuring bindings
+### destructuring bindings
 
 A destructuring `let` binds several names at once from a tuple. Each name takes its type from the corresponding element of the right hand side, and the pattern can nest
 
@@ -21,7 +136,7 @@ let (name, age) = person; // name is string, age is int
 let ((first, second), third) = (("a", "b"), "c");
 ```
 
-## for loop variables
+### for loop variables
 
 A `for` loop variable takes its type from the element type of the iterable being looped over. Destructuring composes with this: when the element type is a tuple, its element types flow into the destructured names
 
@@ -37,9 +152,9 @@ for (name, count) in pairs do // name is string, count is int
 od
 ```
 
-## list literal element type
+### list literal element types
 
-The element type of list literals is inferred from the types of the elements. The compiler will try to find a type that is compatible with all the elements.
+The element type of a list literal is inferred from the types of the elements. The compiler will try to find a type that is compatible with all the elements.
 
 ```ghul
 class Base is
@@ -63,10 +178,9 @@ If a list contains tuple literals, the compiler will attempt to find compatible 
 let int_string = [(123, "hello"), (456, "goodbye")];
 
 let int_object = [(123, 456), (798, "wibble")];
-
 ```
 
-## if expression branch result type
+### if expression result types
 
 The result type of an if expression is inferred from the types of all the branch results. The compiler will try to find a type that is compatible with all the results
 
@@ -86,7 +200,7 @@ let base =
     fi;
 ```
 
-## generic class, struct and variant constructors
+### generic class, struct and variant constructors
 
 When constructing a generic class, struct or variant, the actual generic type arguments will be inferred from the constructor method arguments if possible
 
@@ -107,9 +221,9 @@ let string_thing = THING("hello");
 
 This type of inference is only possible if all type arguments are referenced in the constructor actual arguments and if the constructor overload to call is unambiguous
 
-## generic function or method calls
+### generic function and method calls
 
-When calling a generic global function, a generic method, or a static method on a generic class or struct, the compiler will try to infer the generic type arguments from the types of the actual argument passed to the function or method
+When calling a generic global function, a generic method, or a static method on a generic class or struct, the compiler will try to infer the generic type arguments from the types of the actual arguments passed to the function or method
 
 ```ghul
 do_something[T](a: T, b: T) -> T;
@@ -121,7 +235,7 @@ let derived = do_something(DERIVED(), DERIVED());
 let obj = do_something(object(), DERIVED());
 ```
 
-## anonymous function return type
+### anonymous function return types
 
 When constructing an anonymous function literal, the compiler will attempt to infer the return type from either the type of the expression body or from the type of return expressions in the block body
 
@@ -130,18 +244,19 @@ let returns_int = (i: int) => i * 2;
 let returns_string = (s: string) => "{s}{s}";
 ```
 
-## anonymous function argument types
+### anonymous function argument types
 
 When anonymous function literals are passed as arguments to a function or method and an unambiguous overload match can be made without knowing the exact function type, the compiler can figure out the argument types based on the matching overload.
 
 ```ghul
 [1, 2, 2, 4, 5] | .filter(i => i > 3);
 ```
+
 In this example, `self` is already known to be `Pipe[int]`, so `Pipe[int].filter(predicate: int -> bool) -> Pipe[int]` is the only overload that could match. Hence the `predicate` argument must be `int -> bool` and the type of `i` must be `int`
 
 ## inference from later use sites
 
-The sections above describe types being inferred from the right hand side of a declaration or from the value passed at a call site. When a binding has no immediate clue, the compiler also looks at how it is later used in the same method body and feeds that information back
+The sections above describe types being inferred from the right hand side of a declaration or from the value passed at a call site. Because inference works across the whole function body, the compiler can also infer a binding that has no immediate clue from how it is later used in the same body, feeding that information back
 
 ```ghul
 let m = Box();   // m is Box[?] here — the type argument is not yet known
@@ -156,7 +271,7 @@ let f = x => x + 1;
 write_line("{f(42)}");        // f's argument is inferred as int
 ```
 
-## recursive anonymous functions
+### recursive anonymous functions
 
 In a recursive anonymous function, the argument type can be inferred from how the function is called, including from its own recursive calls
 
@@ -165,7 +280,7 @@ let factorial = n rec => if n == 0 then 1 else n * rec(n - 1) fi;
 write_line("{factorial(5)}");
 ```
 
-## operations on a not yet inferred value
+### operations on a not yet inferred value
 
 When the argument of an anonymous function has no annotation and the body uses it — accessing a member, calling a method, indexing, iterating, or destructuring — the compiler records what the argument must support. When a call later supplies a concrete type, candidate types are filtered against those operations
 
@@ -174,7 +289,7 @@ let length_of = x => x.length;
 write_line("{length_of("hello")}"); // x resolves to string
 ```
 
-## generic argument inference from sibling actuals
+### generic argument inference from sibling actuals
 
 When a generic function or method is called with two arguments that share only a common ancestor, the generic argument is inferred from their nearest shared type rather than failing the overload match
 

--- a/src/type-inference.md
+++ b/src/type-inference.md
@@ -1,10 +1,10 @@
 # type inference
 
-ghūl infers types pervasively. Inside a method or function body, most local variables, loop variables, destructured variables and anonymous function parameters can be left unannotated — the compiler works their types out from how they are initialized and from how they are later used.
+ghūl infers types pervasively. Inside a method or function body, most local variables, loop variables, destructured variables and anonymous function parameters can be left unannotated - the compiler works their types out from how they are initialized and used.
 
-Type inference is **function-local**. Type information inferred within one function is not visible outside that function, and outside function bodies all types are explicit — this includes the signatures of methods and global functions, whose parameter types and return types are always written out.
+Type inference is **function-local**: types inferred within one function are not visible outside it. Outside function bodies all types are explicit, including the signatures of methods and global functions, whose parameter and return types are always written out.
 
-Within a function, types are inferred only for certain kinds of symbol:
+Within a function, types are inferred for:
 
 - local variables
 - loop variables
@@ -13,11 +13,11 @@ Within a function, types are inferred only for certain kinds of symbol:
 - anonymous function return types
 - generic type arguments on calls to constructors, methods, static methods and global functions
 
-ghūl also performs **type narrowing** — within parts of a function a symbol may be observed at a more specific type than the one it was declared with. Narrowing applies only to local variables: function parameters, `let` variables, loop variables, destructured variables and anonymous function parameters. It does not apply to fields or properties.
+ghūl also performs **type narrowing** - within parts of a function a symbol may be observed at a more specific type than the one it was declared with. Narrowing applies only to local variables: function parameters, `let` variables, loop variables, destructured variables and anonymous function parameters. It does not apply to fields or properties.
 
 ## inference is function-local
 
-A function's signature is written out explicitly. Inference then works within the body
+A function's signature is written out explicitly; inference works within the body.
 
 ```ghul
 // the signature is explicit: the parameter type and the return type are written out
@@ -34,22 +34,22 @@ totals(values: Collections.Iterable[int]) -> (sum: int, count: int) is
 si
 ```
 
-Inference stays inside the body. It does not read types out of a body into that function's signature, and it does not carry from one function into another: each body is checked on its own, against the explicit signatures of everything it calls.
+Inference does not read types out of a body into that function's signature, and does not carry from one function into another: each body is checked on its own, against the explicit signatures of everything it calls.
 
 ## inference applies to local symbols
 
-Inference is function-local, so it only ever works out the types of symbols that are local to a function body. A field or property belongs to a type rather than to any one function body, so its type is always written out explicitly — for a private member no less than a public one
+Because inference is function-local, it only works out the types of symbols local to a function body. A field or property belongs to a type rather than to a function body, so its type is always written out explicitly - for private members as well as public ones.
 
 ```ghul
 class COUNTER is
-    count: int;          // a property — its type is declared
+    count: int;          // a property - its type is declared
 
     init() is
         count = 0;
     si
 
     tick() is
-        let step = 1;    // a local — its type is inferred from the initializer
+        let step = 1;    // a local - its type is inferred from the initializer
         count = count + step;
     si
 si
@@ -57,7 +57,7 @@ si
 
 ## type narrowing
 
-When a check proves a stronger fact about a value's type, ghūl narrows that value to the narrower type for the code the fact covers. Narrowing applies to local variables — including a function's own parameters
+When a check proves a stronger fact about a value's type, ghūl narrows that value to the narrower type for the code the fact covers. Narrowing applies to local variables, including a function's own parameters.
 
 ```ghul
 greet(a: Animal) is
@@ -68,7 +68,7 @@ greet(a: Animal) is
 si
 ```
 
-A field or property is **not** narrowed — an `isa` check or variant test written directly against one narrows nothing
+A field or property is **not** narrowed - an `isa` check or variant test written directly against one narrows nothing.
 
 ```ghul
 class CARRIER is
@@ -83,14 +83,14 @@ si
 
 describe(carrier: CARRIER) is
     if isa Cat(carrier.occupant) then
-        // carrier.occupant is a property access, not a local variable — it is
+        // carrier.occupant is a property access, not a local variable - it is
         // not narrowed, so carrier.occupant.purr() would not compile here
         write_line("the carrier holds a cat");
     fi
 si
 ```
 
-ghūl narrows local variables only. Narrowing a field or property is possible in principle, but ghūl deliberately keeps narrowing simple and does not. To narrow a property, copy it into a local variable and narrow that
+To narrow a property, copy it into a local variable and narrow that.
 
 ```ghul
 describe(carrier: CARRIER) is
@@ -103,7 +103,7 @@ describe(carrier: CARRIER) is
 si
 ```
 
-`if let` does the same in one step: it introduces a fresh local variable from the property expression, and that local narrows
+`if let` does the same in one step: it introduces a fresh local variable from the property expression, and that local narrows.
 
 ```ghul
 describe(carrier: CARRIER) is
@@ -113,13 +113,13 @@ describe(carrier: CARRIER) is
 si
 ```
 
-Narrowing covers union variant tags, `isa` class checks, null checks (`x?`) and `if let`, and it is flow-sensitive — an early-return guard narrows the code that follows it. See [type narrowing and `if let`](/control-flow.html#type-narrowing) in the control flow chapter for the full picture.
+Narrowing covers union variant tags, `isa` class checks, null checks (`x?`) and `if let`, and it is flow-sensitive - an early-return guard narrows the code that follows it. See [type narrowing and `if let`](/control-flow.html#type-narrowing) in the control flow chapter for the full picture.
 
 ## what gets inferred
 
 ### let statements and expressions
 
-When no explicit type is given for a variable in a let statement or expression, the variable type is inferred from the initializer, provided one is present
+When no explicit type is given for a variable in a let statement or expression, its type is inferred from the initializer, provided one is present.
 
 ```ghul
 let a_string = "12345";
@@ -129,7 +129,7 @@ let an_int_array = [1, 2, 3, 4, 5];
 
 ### destructuring variables
 
-A destructuring `let` declares several variables at once from a tuple. Each variable takes its type from the corresponding element of the right-hand side, and the pattern can nest
+A destructuring `let` declares several variables at once from a tuple. Each variable takes its type from the corresponding element of the right-hand side, and the pattern can nest.
 
 ```ghul
 let person = ("alice", 30);
@@ -140,7 +140,7 @@ let ((first, second), third) = (("a", "b"), "c");
 
 ### for loop variables
 
-A `for` loop variable takes its type from the element type of the iterable being looped over. Destructuring composes with this: when the element type is a tuple, its element types flow into the destructured names
+A `for` loop variable takes its type from the element type of the iterable being looped over. Destructuring composes with this: when the element type is a tuple, its element types flow into the destructured names.
 
 ```ghul
 for i in 1::10 do // i is int
@@ -156,7 +156,7 @@ od
 
 ### list literal element types
 
-The element type of a list literal is inferred from the types of the elements. The compiler will try to find a type that is compatible with all the elements.
+The element type of a list literal is inferred from the types of the elements: the compiler finds a type compatible with all of them.
 
 ```ghul
 class Base is
@@ -174,7 +174,7 @@ let array_of_object = [Base(), DERIVED(), object()];
 let array_of_int = [1, 2, 3, 4, 5];
 ```
 
-If a list contains tuple literals, the compiler will attempt to find compatible common types for each tuple element across all the elements in the list
+If a list contains tuple literals, the compiler finds a compatible common type for each tuple element across all elements of the list.
 
 ```ghul
 let int_string = [(123, "hello"), (456, "goodbye")];
@@ -184,7 +184,7 @@ let int_object = [(123, 456), (798, "wibble")];
 
 ### if expression result types
 
-The result type of an if expression is inferred from the types of all the branch results. The compiler will try to find a type that is compatible with all the results
+The result type of an if expression is inferred from the types of all the branch results: the compiler finds a type compatible with all of them.
 
 ```ghul
 let derived =
@@ -204,7 +204,7 @@ let base =
 
 ### generic class, struct and variant constructors
 
-When constructing a generic class, struct or variant, the actual generic type arguments will be inferred from the constructor method arguments if possible
+When constructing a generic class, struct or variant, the generic type arguments are inferred from the constructor method arguments where possible.
 
 ```ghul
 class THING[T] is
@@ -221,11 +221,11 @@ let int_thing = THING(1234);
 let string_thing = THING("hello");
 ```
 
-Inference from the constructor arguments works when every type argument appears among those arguments and the constructor overload is unambiguous. A type argument left unpinned — by a no-argument constructor, say — can still be resolved from later use of the value (see [inference from later use sites](#inference-from-later-use-sites)).
+Inference from the constructor arguments works when every type argument appears among those arguments and the constructor overload is unambiguous. A type argument left unpinned - by a no-argument constructor, say - can still be resolved from later use of the value (see [inference from later use sites](#inference-from-later-use-sites)).
 
 ### generic function and method calls
 
-When calling a generic global function, a generic method, or a static method on a generic class or struct, the compiler will try to infer the generic type arguments from the types of the actual arguments passed to the function or method
+When calling a generic global function, a generic method, or a static method on a generic class or struct, the compiler infers the generic type arguments from the types of the actual arguments passed.
 
 ```ghul
 do_something[T](a: T, b: T) -> T;
@@ -239,7 +239,7 @@ let obj = do_something(object(), DERIVED());
 
 ### anonymous function return types
 
-When constructing an anonymous function literal, the compiler will attempt to infer the return type from either the type of the expression body or from the type of return expressions in the block body
+The return type of an anonymous function literal is inferred from the type of its expression body, or from the types of return expressions in its block body.
 
 ```ghul
 let returns_int = (i: int) => i * 2;
@@ -248,25 +248,25 @@ let returns_string = (s: string) => "{s}{s}";
 
 ### anonymous function argument types
 
-When anonymous function literals are passed as arguments to a function or method and an unambiguous overload match can be made without knowing the exact function type, the compiler can figure out the argument types based on the matching overload.
+When an anonymous function literal is passed as an argument and an unambiguous overload match can be made without knowing the exact function type, the compiler infers the argument types from the matching overload.
 
 ```ghul
 [1, 2, 2, 4, 5] | .filter(i => i > 3);
 ```
 
-In this example, `self` is already known to be `Pipe[int]`, so `Pipe[int].filter(predicate: int -> bool) -> Pipe[int]` is the only overload that could match. Hence the `predicate` argument must be `int -> bool` and the type of `i` must be `int`
+Here `self` is already known to be `Pipe[int]`, so `Pipe[int].filter(predicate: int -> bool) -> Pipe[int]` is the only overload that could match. The `predicate` argument must therefore be `int -> bool`, and the type of `i` must be `int`.
 
 ## inference from later use sites
 
-The sections above describe types being inferred from the right hand side of a declaration or from the value passed at a call site. Because inference works across the whole function body, the compiler can also infer a binding that has no immediate clue from how it is later used in the same body, feeding that information back
+The sections above describe types inferred from the right-hand side of a declaration or from the value passed at a call site. Because inference works across the whole function body, the compiler can also infer a variable that has no immediate clue from how it is later used in the same body, feeding that information back.
 
 ```ghul
-let m = Box();   // m is Box[?] here — the type argument is not yet known
+let m = Box();   // m is Box[?] here - the type argument is not yet known
 m.set(42);       // the set call carries an int, so m is Box[int]
 let x = m.get(); // x reads as int
 ```
 
-The same applies to let-bound anonymous functions whose argument types are not annotated. A later call supplies a concrete type which flows back to the function literal
+The same applies to let-bound anonymous functions whose argument types are not annotated: a later call supplies a concrete type, which flows back to the function literal.
 
 ```ghul
 let f = x => x + 1;
@@ -275,7 +275,7 @@ write_line("{f(42)}");        // f's argument is inferred as int
 
 ### recursive anonymous functions
 
-In a recursive anonymous function, the argument type can be inferred from how the function is called, including from its own recursive calls
+In a recursive anonymous function, the argument type can be inferred from how the function is called, including from its own recursive calls.
 
 ```ghul
 let factorial = n rec => if n == 0 then 1 else n * rec(n - 1) fi;
@@ -284,18 +284,18 @@ write_line("{factorial(5)}");
 
 ### operations on a not yet inferred value
 
-When an anonymous function's parameter has no annotation, every operation the body performs on it — a member access, a method call, an index, an iteration, a destructuring — is recorded as something the parameter's type must support. When a call later supplies a concrete type, that type has to satisfy the recorded operations
+When an anonymous function's parameter has no annotation, every operation the body performs on it - a member access, a method call, an index, an iteration, a destructuring - is recorded as a requirement on the parameter's type. A later call must supply a type that satisfies all of them.
 
 ```ghul
 let length_of = x => x.length;
 write_line("{length_of("hello")}"); // x resolves to string
 ```
 
-The call passes a `string`, and `string` has a `length` member, so `x` resolves to `string`. The recorded operations earn their keep when the call site leaves room for more than one type: a candidate that does not support every operation the body relies on is discarded.
+The call passes a `string`, and `string` has a `length` member, so `x` resolves to `string`. When a call site leaves room for more than one type, a candidate that does not support every recorded operation is discarded.
 
 ### generic argument inference from sibling actuals
 
-When a generic function or method is called with two arguments that share only a common ancestor, the generic argument is inferred from their nearest shared type rather than failing the overload match
+When a generic function or method is called with two arguments that share only a common ancestor, the generic argument is inferred from their nearest shared type rather than failing the overload match.
 
 ```ghul
 class Animal is

--- a/src/type-inference.md
+++ b/src/type-inference.md
@@ -1,17 +1,23 @@
 # type inference
 
-ghūl infers types pervasively. Inside a function body most local variables, loop variables, destructured bindings and lambda parameters can be left unannotated — the compiler works their types out from how they are initialized and from how they are later used.
+ghūl infers types pervasively. Inside a method or function body, most local variables, loop variables, destructured variables and anonymous function parameters can be left unannotated — the compiler works their types out from how they are initialized and from how they are later used.
 
-Two boundaries are worth understanding up front, because together they explain both what inference will do for you and what it will not:
+Type inference is **function-local**. Type information inferred within one function is not visible outside that function, and outside function bodies all types are explicit — this includes the signatures of methods and global functions, whose parameter types and return types are always written out.
 
-- Inference is **function-local**. The compiler works within one function body at a time. A function's signature — its parameter types and, where it returns a value, its return type — is always written out explicitly.
-- Inference applies to **local symbols** only. Local variables, loop variables, destructured bindings and lambda parameters have inferred types. Fields and properties carry declared types.
+Within a function, types are inferred only for certain kinds of symbol:
 
-The same two boundaries govern type narrowing: a local can be narrowed by a test that proves a stronger fact about it, but a field or property cannot.
+- local variables
+- loop variables
+- destructured variables
+- anonymous function parameters
+- anonymous function return types
+- generic type arguments on calls to constructors, methods, static methods and global functions
+
+ghūl also performs **type narrowing** — within parts of a function a symbol may be observed at a more specific type than the one it was declared with. Narrowing applies only to local variables: function parameters, `let` variables, loop variables, destructured variables and anonymous function parameters. It does not apply to fields or properties.
 
 ## inference is function-local
 
-A function's signature is written out explicitly. Inference then has free rein inside the body
+A function's signature is written out explicitly. Inference then works within the body
 
 ```ghul
 // the signature is explicit: the parameter type and the return type are written out
@@ -24,17 +30,15 @@ totals(values: Collections.Iterable[int]) -> (sum: int, count: int) is
         count = count + 1;
     od
 
-    (sum, count);
+    return (sum, count);
 si
 ```
 
-Inference does not flow the other way. It never reads a type back out of a function body into that function's signature, and it never crosses from one function into another. Each body is checked on its own, against the fixed signatures of everything it calls.
-
-This is what makes signatures the stable contract between functions — and it is also why a named function's return type is written out, while an anonymous function's return type is inferred: a lambda has no separate signature to honour, so there is nothing for an explicit return type to agree with.
+Inference stays inside the body. It does not read types out of a body into that function's signature, and it does not carry from one function into another: each body is checked on its own, against the explicit signatures of everything it calls.
 
 ## inference applies to local symbols
 
-A field or property is part of a type's surface — other code relies on its type — so its type is declared. A local variable exists only for the duration of one call, so the compiler is free to infer it
+Inference is function-local, so it only ever works out the types of symbols that are local to a function body. A field or property belongs to a type rather than to any one function body, so its type is always written out explicitly — for a private member no less than a public one
 
 ```ghul
 class COUNTER is
@@ -51,23 +55,23 @@ class COUNTER is
 si
 ```
 
-## narrowing respects the same boundary
+## type narrowing
 
-When a test proves a stronger fact about a value's type, ghūl narrows that value to the narrower type for the code the fact covers. Narrowing applies to local symbols — including a function's own parameters, which are locals of that function
+When a check proves a stronger fact about a value's type, ghūl narrows that value to the narrower type for the code the fact covers. Narrowing applies to local variables — including a function's own parameters
 
 ```ghul
 greet(a: Animal) is
     if isa Cat(a) then
-        // a is a local of greet, narrowed to Cat in this branch
+        // a is a parameter of greet, narrowed to Cat in this branch
         write_line(a.purr());
     fi
 si
 ```
 
-A field or property is **not** narrowed, even by a test written directly against it
+A field or property is **not** narrowed — an `isa` check or variant test written directly against one narrows nothing
 
 ```ghul
-class CAGE is
+class CARRIER is
     occupant: Animal;
 
     init(occupant: Animal) is
@@ -77,41 +81,39 @@ si
 
 ...
 
-describe(cage: CAGE) is
-    if isa Cat(cage.occupant) then
-        // cage.occupant is a property access, not a local — it is not narrowed,
-        // so cage.occupant.purr() would not compile here
-        write_line("the cage holds a cat");
+describe(carrier: CARRIER) is
+    if isa Cat(carrier.occupant) then
+        // carrier.occupant is a property access, not a local variable — it is
+        // not narrowed, so carrier.occupant.purr() would not compile here
+        write_line("the carrier holds a cat");
     fi
 si
 ```
 
-The compiler cannot carry the proven fact from the test to a later use, because a property access is re-evaluated every time it is written — there is no single, stable location to track. A field could be reassigned between the two points. A local that is not reassigned in between gives the compiler something it can rely on.
-
-To narrow a property, copy it into a local and test the local
+ghūl narrows local variables only. Narrowing a field or property is possible in principle, but ghūl deliberately keeps narrowing simple and does not. To narrow a property, copy it into a local variable and narrow that
 
 ```ghul
-describe(cage: CAGE) is
-    let occupant = cage.occupant;  // copy the property into a local
+describe(carrier: CARRIER) is
+    let occupant = carrier.occupant;  // copy the property into a local variable
 
     if isa Cat(occupant) then
-        // occupant is a local, narrowed to Cat in this branch
+        // occupant is a local variable, narrowed to Cat in this branch
         write_line(occupant.purr());
     fi
 si
 ```
 
-`if let` does the same in one step: it binds a fresh local from the property expression, and that local narrows
+`if let` does the same in one step: it introduces a fresh local variable from the property expression, and that local narrows
 
 ```ghul
-describe(cage: CAGE) is
-    if let cat: Cat = cage.occupant then
+describe(carrier: CARRIER) is
+    if let cat: Cat = carrier.occupant then
         write_line(cat.purr());
     fi
 si
 ```
 
-Narrowing covers union variant tags, `isa` class tests, null tests (`x?`) and `if let` bindings, and it is flow-sensitive — an early-return guard narrows the code that follows it. See [type narrowing and `if let`](/control-flow.html#type-narrowing) in the control flow chapter for the full picture.
+Narrowing covers union variant tags, `isa` class checks, null checks (`x?`) and `if let`, and it is flow-sensitive — an early-return guard narrows the code that follows it. See [type narrowing and `if let`](/control-flow.html#type-narrowing) in the control flow chapter for the full picture.
 
 ## what gets inferred
 
@@ -125,9 +127,9 @@ let an_int = 12345;
 let an_int_array = [1, 2, 3, 4, 5];
 ```
 
-### destructuring bindings
+### destructuring variables
 
-A destructuring `let` binds several names at once from a tuple. Each name takes its type from the corresponding element of the right hand side, and the pattern can nest
+A destructuring `let` declares several variables at once from a tuple. Each variable takes its type from the corresponding element of the right-hand side, and the pattern can nest
 
 ```ghul
 let person = ("alice", 30);
@@ -219,7 +221,7 @@ let int_thing = THING(1234);
 let string_thing = THING("hello");
 ```
 
-This type of inference is only possible if all type arguments are referenced in the constructor actual arguments and if the constructor overload to call is unambiguous
+Inference from the constructor arguments works when every type argument appears among those arguments and the constructor overload is unambiguous. A type argument left unpinned — by a no-argument constructor, say — can still be resolved from later use of the value (see [inference from later use sites](#inference-from-later-use-sites)).
 
 ### generic function and method calls
 
@@ -282,12 +284,14 @@ write_line("{factorial(5)}");
 
 ### operations on a not yet inferred value
 
-When the argument of an anonymous function has no annotation and the body uses it — accessing a member, calling a method, indexing, iterating, or destructuring — the compiler records what the argument must support. When a call later supplies a concrete type, candidate types are filtered against those operations
+When an anonymous function's parameter has no annotation, every operation the body performs on it — a member access, a method call, an index, an iteration, a destructuring — is recorded as something the parameter's type must support. When a call later supplies a concrete type, that type has to satisfy the recorded operations
 
 ```ghul
 let length_of = x => x.length;
 write_line("{length_of("hello")}"); // x resolves to string
 ```
+
+The call passes a `string`, and `string` has a `length` member, so `x` resolves to `string`. The recorded operations earn their keep when the call site leaves room for more than one type: a candidate that does not support every operation the body relies on is discarded.
 
 ### generic argument inference from sibling actuals
 


### PR DESCRIPTION
- Open the type inference page with the two boundaries that frame ghūl inference: it is function-local, and it applies to local symbols only. New "inference is function-local" and "inference applies to local symbols" sections explain each.
- Add a "narrowing respects the same boundary" section: a local (including a parameter) narrows under a type test, a field or property does not — copy the property into a local, or bind one with `if let`, to narrow it. Cross-references the control flow chapter for the narrowing mechanics.
- Group the existing mechanical sections under "what gets inferred", unchanged in substance.