### PR TITLE
Add CNAME to the published site root so the custom domain persists

### DIFF
--- a/src/.vuepress/public/CNAME
+++ b/src/.vuepress/public/CNAME
@@ -1,0 +1,1 @@
+ghul.dev


### PR DESCRIPTION
Bugs fixed:

- The deploy publishes to `gh-pages:/docs`, but the `CNAME` file only existed at the `gh-pages` branch root — not in the published path GitHub reads. A Pages rebuild finding no `CNAME` there cleared the `ghul.dev` custom domain. Adding `CNAME` to `src/.vuepress/public/` makes VuePress copy it into the build output, so it lands at `gh-pages:/docs/CNAME` and the custom domain survives rebuilds.