### PR TITLE
Reword the examples tip; drop duplicate examples-repo pointers

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -29,8 +29,8 @@ ghūl is mainly an opportunity for [me](https://github.com/degory) to experiment
 
 ## examples
 
-::: tip the examples are live
-Every example on this site is compiled and run with a pinned ghūl compiler. Hover any identifier to see its type; open the panel beneath an example for its captured output or compiler diagnostics.
+::: tip interactive examples
+Hover any identifier in a code example to see its type. An example's output and any compiler diagnostics appear in a panel beneath it.
 :::
 
 ### hello world!
@@ -44,6 +44,3 @@ Every example on this site is compiled and run with a pinned ghūl compiler. Hov
 ### OOP
 
 <GhulExample name="object-oriented" />
-
-### examples project
-See the [ghūl examples repository](https://github.com/degory/ghul-examples) for projects with these examples and others that can be viewed, edited and run from Visual Studio Code or a GitHub Codespace.

--- a/src/tooling.md
+++ b/src/tooling.md
@@ -43,7 +43,7 @@ On large projects the extension updates this analysis in two stages — a quick 
 
 A [development container image](https://github.com/users/degory/packages/container/package/ghul%2Fdevcontainer) is published with the compiler, the .NET SDK, and the supporting tools pre-installed. Opening a project in this container — locally with the VS Code Dev Containers extension, or in a GitHub Codespace — gives you a ready-to-build ghūl environment with nothing to install.
 
-The [ghūl examples repository](https://github.com/degory/ghul-examples) and the [ghūl repository template](https://github.com/degory/ghul-repository-template) are both set up to open in this container.
+The [ghūl repository template](https://github.com/degory/ghul-repository-template) is also set up to open in this container.
 
 ## project templates
 


### PR DESCRIPTION
The index page's tip claimed the examples are "live" — they are pre-rendered offline, not live — and mentioned the pinned compiler, which is irrelevant to a reader. It now states only what the reader can do: hover for types, with output and diagnostics in a panel beneath an example.

The per-topic tips already point at the examples repository, so the near-duplicate pointers on the index and tooling pages are removed — tooling keeps its repository-template mention.