### PR TITLE
Drop the bespoke ghūl devcontainer recommendation

### DIFF
--- a/src/getting-started.md
+++ b/src/getting-started.md
@@ -22,9 +22,9 @@ If you initialize your project using one of the [ghūl .NET project templates](h
 
 If you create a new GitHub repo from the [ghūl repository template](https://github.com/degory/ghul-repository-template), then the compiler will be pre-configured as a local .NET tool in your project folder - run `dotnet tool restore`{:sh} to restore it.
 
-### use the ghūl development container image
+### use a dev container
 
-The compiler is pre-installed globally in the [ghūl development container](https://github.com/users/degory/packages/container/package/ghul%2Fdevcontainer)
+The [examples repository](https://github.com/degory/ghul-examples) and the [ghūl repository template](https://github.com/degory/ghul-repository-template) both ship a `.devcontainer` configured to use a standard .NET 8 dev container image — for example [`mcr.microsoft.com/devcontainers/dotnet:8.0`](https://hub.docker.com/r/microsoft/devcontainers-dotnet). Open the project in VS Code with the Dev Containers extension, or in a GitHub Codespace, and run `dotnet tool restore`{:sh} to install the compiler from the local tool manifest.
 
 ### install the compiler as a local or global .NET tool
 

--- a/src/tooling.md
+++ b/src/tooling.md
@@ -39,11 +39,9 @@ Behind the scenes the extension runs the ghūl compiler in its analysis mode: th
 
 On large projects the extension updates this analysis in two stages — a quick partial pass over the file you are editing, followed by a full pass once you pause. This is usually invisible, though it does mean a diagnostic can occasionally appear or disappear a moment after an edit.
 
-## the development container
+## dev containers
 
-A [development container image](https://github.com/users/degory/packages/container/package/ghul%2Fdevcontainer) is published with the compiler, the .NET SDK, and the supporting tools pre-installed. Opening a project in this container — locally with the VS Code Dev Containers extension, or in a GitHub Codespace — gives you a ready-to-build ghūl environment with nothing to install.
-
-The [ghūl repository template](https://github.com/degory/ghul-repository-template) is also set up to open in this container.
+The ghūl repository template and the examples repo both ship a `.devcontainer` configured to use a standard .NET 8 dev container image — for example [`mcr.microsoft.com/devcontainers/dotnet:8.0`](https://hub.docker.com/r/microsoft/devcontainers-dotnet). Open the project in VS Code with the Dev Containers extension, or in a GitHub Codespace, and `dotnet tool restore`{:sh} will install the compiler from the local tool manifest. Any image with the .NET 8 SDK and `dotnet`{:text} on the PATH will work.
 
 ## project templates
 


### PR DESCRIPTION
The custom `ghcr.io/degory/ghul/devcontainer:dotnet` image is being retired across the ghūl repos: it layered a system-wide install of `ghul.compiler` (shadowed by the local tool manifest anyway) and a `vscode` non-root user (`mcr.microsoft.com/devcontainers/dotnet:8.0` already provides one) onto the stock .NET 8 SDK. Steering users at a standard MS .NET 8 dev container image removes a dependency on project infrastructure without losing anything used in practice.

Technical:

- `src/getting-started.md`: "use the ghūl development container image" becomes "use a dev container", recommending `mcr.microsoft.com/devcontainers/dotnet:8.0` as the example image and pointing users at the examples repo and the repository template.
- `src/tooling.md`: "the development container" section is rewritten in the same terms, dropping the line about the template being set up to open in the bespoke container.

Sibling PRs (same theme): degory/ghul, degory/ghul-test, degory/ghul-runtime, degory/ghul-examples.